### PR TITLE
Add prettier rules to @mineiros/eslint-config-typescript

### DIFF
--- a/packages/eslint-config-vue/index.js
+++ b/packages/eslint-config-vue/index.js
@@ -16,7 +16,7 @@ module.exports = {
     'plugin:vue/vue3-recommended',
     '@mineiros/eslint-config-typescript',
     '@vue/prettier',
-    '@vue/prettier/@typescript-eslint'
+    '@vue/prettier/@typescript-eslint',
   ],
   plugins: ['vue'],
   rules: {
@@ -30,5 +30,13 @@ module.exports = {
       },
     ],
     // 'vue/no-v-html': 'off',
+    'prettier/prettier': [
+      'warn',
+      {
+        singleQuote: true,
+        semi: false,
+        trailingComma: 'es5',
+      },
+    ],
   },
 }


### PR DESCRIPTION
This adds some minor prettier rules to the `@mineiros/eslint-config-vue` package. In a next step, I will split up prettier and eslint and provide two additional packages for the eslint-prettier integrations so that eslint may also be used without prettier (that's what I typically to for module development)